### PR TITLE
fix: make behavior consistent for undefined nested fields and newer TS targets

### DIFF
--- a/src/utils/EntityTransformer.ts
+++ b/src/utils/EntityTransformer.ts
@@ -47,13 +47,6 @@ export class EntityTransformer {
       });
     }
 
-    // avoids edge case where some consumers populate missing fields with undefined
-    for (const [k, v] of Object.entries(entity)) {
-      if (v === undefined) {
-        delete entity[k];
-      }
-    }
-
     const dbEntityData: Record<string, unknown> = {};
     for (const prop of props) {
       // eslint-disable-next-line no-prototype-builtins
@@ -61,14 +54,15 @@ export class EntityTransformer {
         continue;
       }
 
-      if (prop.isNested) {
+      const value = entity[prop.options.entityPropName];
+      if (prop.isNested && value !== undefined && value !== null) {
         dbEntityData[prop.options.name] = this.normalizeProps(
-          entity[prop.options.entityPropName],
+          value,
           prop.props,
           meta,
         );
       } else {
-        dbEntityData[prop.options.name] = entity[prop.options.entityPropName];
+        dbEntityData[prop.options.name] = value;
       }
     }
     return dbEntityData;

--- a/src/utils/EntityTransformer.ts
+++ b/src/utils/EntityTransformer.ts
@@ -1,12 +1,12 @@
-import { MetaLoader } from './MetaLoader';
-import { ClassType } from '../types/Class.type';
 import { NormalizedEntity } from '../entity/Normalized.entity';
+import { EsValidationException } from '../exceptions/EsValidationException';
+import { ClassType } from '../types/Class.type';
 import {
   EsMetaDataInterface,
   EsPropsMetaDataInterface,
 } from '../types/EsMetaData.interface';
-import { EsValidationException } from '../exceptions/EsValidationException';
 import { EsPropertyTypedOptions } from '../types/EsPropertyOptions.intarface';
+import { MetaLoader } from './MetaLoader';
 
 export class EntityTransformer {
   constructor(private readonly metaLoader: MetaLoader) {}
@@ -45,6 +45,13 @@ export class EntityTransformer {
       return entity.map((entityItem) => {
         return this.normalizeProps(entityItem, props, meta);
       });
+    }
+
+    // avoids edge case where some consumers populate missing fields with undefined
+    for (const [k, v] of Object.entries(entity)) {
+      if (v === undefined) {
+        delete entity[k];
+      }
     }
 
     const dbEntityData: Record<string, unknown> = {};

--- a/test/fixtures/TestingClassNested.ts
+++ b/test/fixtures/TestingClassNested.ts
@@ -1,0 +1,23 @@
+import { EsEntity } from '../../src/decorators/EsEntity';
+import { EsId } from '../../src/decorators/EsId';
+import { EsProperty } from '../../src/decorators/EsProperty';
+
+export class MyNestedEntity {
+  @EsProperty('keyword')
+  public name: string;
+}
+
+@EsEntity('elastic_index')
+export class MyRootEntity {
+  @EsId()
+  public id: string;
+
+  @EsProperty('integer')
+  public foo: number;
+
+  @EsProperty({ type: 'nested', entity: MyNestedEntity })
+  public nestedItem: MyNestedEntity;
+
+  @EsProperty({ type: 'nested', entity: MyNestedEntity })
+  public nestedItems: MyNestedEntity[];
+}

--- a/test/fixtures/TestingClassNested.ts
+++ b/test/fixtures/TestingClassNested.ts
@@ -16,8 +16,8 @@ export class MyRootEntity {
   public foo: number;
 
   @EsProperty({ type: 'nested', entity: MyNestedEntity })
-  public nestedItem: MyNestedEntity;
+  public nestedItem?: MyNestedEntity;
 
   @EsProperty({ type: 'nested', entity: MyNestedEntity })
-  public nestedItems: MyNestedEntity[];
+  public nestedItems?: MyNestedEntity[];
 }

--- a/test/unit/src/utils/EntityTransformer.spec.ts
+++ b/test/unit/src/utils/EntityTransformer.spec.ts
@@ -110,14 +110,24 @@ describe('entity transformer', () => {
     expect(normalizedEntityRetried).toMatchObject(normalizedEntity);
   });
 
-  it('should work for nested entities - edge case: optional field set to undefined', () => {
+  it('should work for nested entities - optional fields', () => {
     const testingClass1 = new MyRootEntity();
     testingClass1.id = '25u46fhno';
     testingClass1.foo = 1;
-    Object.assign(testingClass1, {
-      nestedItem: undefined,
-      nestedItems: undefined,
-    });
+
+    // remove block in the future
+    // see: https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-7.html#the-usedefineforclassfields-flag-and-the-declare-property-modifier
+    {
+      const recentTsTarget = Object.keys(testingClass1).includes('nestedItem');
+      if (!recentTsTarget) {
+        console.debug('older TS target');
+        // make test object look like what newer TS targets generate
+        Object.assign(testingClass1, {
+          nestedItem: undefined,
+          nestedItems: undefined,
+        });
+      }
+    }
 
     const normalizedEntity = entityTransformer.normalize(testingClass1);
     expect(normalizedEntity.id).toBe('25u46fhno');
@@ -130,9 +140,7 @@ describe('entity transformer', () => {
       normalizedEntity,
     );
 
-    // clean the expected object because
-    // denormalize is coming back from DB on a new instance
-    // so it can't know what erroneous `undefined`s were in the original
+    // remove in future, clean the expected object in-case undefined affects properties
     for (const [k, v] of Object.entries(testingClass1)) {
       if (v === undefined) {
         delete testingClass1[k];
@@ -141,6 +149,7 @@ describe('entity transformer', () => {
 
     expect(denormalizedEntity).toMatchObject(testingClass1);
 
+    // remove in future
     for (const [k, v] of Object.entries(normalizedEntity.data)) {
       if (v === undefined) {
         delete normalizedEntity.data[k];

--- a/test/unit/src/utils/EntityTransformer.spec.ts
+++ b/test/unit/src/utils/EntityTransformer.spec.ts
@@ -130,7 +130,22 @@ describe('entity transformer', () => {
       normalizedEntity,
     );
 
+    // clean the expected object because
+    // denormalize is coming back from DB on a new instance
+    // so it can't know what erroneous `undefined`s were in the original
+    for (const [k, v] of Object.entries(testingClass1)) {
+      if (v === undefined) {
+        delete testingClass1[k];
+      }
+    }
+
     expect(denormalizedEntity).toMatchObject(testingClass1);
+
+    for (const [k, v] of Object.entries(normalizedEntity.data)) {
+      if (v === undefined) {
+        delete normalizedEntity.data[k];
+      }
+    }
 
     const normalizedEntityRetried =
       entityTransformer.normalize(denormalizedEntity);


### PR DESCRIPTION
We encountered runtime errors when omitting a nested field. I'm not sure if the library intends to support optional nested fields or not.

If it does, the current code can throw if the consuming application's tsconfig has a newer `target`. The way uninitialized fields are treated is changing: https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-7.html#the-usedefineforclassfields-flag-and-the-declare-property-modifier .

The relevant lines are

https://github.com/Twiddlle/elasticsearch-orm/blob/f017a251a558edb2b795a6db7e91882417c582b3/src/utils/EntityTransformer.ts#L51-L59

That config change affects whether an `undefined` value is enumerated on line 51, and then recursed on line 58, causing an NPE-like error on line 53.

![Screenshot 2025-04-16 at 9 03 34 AM](https://github.com/user-attachments/assets/3a204940-7acf-41b0-9443-1f299e412e78)

To verify, you can change the target in your tsconfig to `ES2022` and remove the application code tweak in this PR and the new unit test will fail. I'm not sure the fix in this PR is ideal, feel free to change / suggest-changes, but the new unit test demonstrates our current usage / config.
